### PR TITLE
set ulimit

### DIFF
--- a/core/set-kernel-param.sh
+++ b/core/set-kernel-param.sh
@@ -2,4 +2,4 @@
 
 set -exo pipefail
 
-ulimit -n 65536
+ulimit -n 262144

--- a/core/set-kernel-param.sh
+++ b/core/set-kernel-param.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -exo pipefail
+
+ulimit -n 65536


### PR DESCRIPTION
mountpoint-s3でs3のリソースにアクセスする際にエラーになる問題の対策です。
下のulimitが1024と小さかったため変更します。

JIRA: https://turing-motors.atlassian.net/browse/MLOP-404