### PR TITLE
kernel parameterを設定するスクリプトを削除

### DIFF
--- a/core/set-kernel-param.sh
+++ b/core/set-kernel-param.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -exo pipefail
-
-ulimit -n 262144


### PR DESCRIPTION
parallel clusterのmount-s3の安定化のために作りましたが、不要なため消します。

## 関連PR
https://github.com/turingmotors/aws-parallelcluster-scripts/pull/1