### PR TITLE
mount-s3がhungした時に自動でリスタートさせる

### DIFF
--- a/mount-s3/mount.sh
+++ b/mount-s3/mount.sh
@@ -16,7 +16,6 @@ OPTIONS=("$@")
 # 固定パラメータ
 WRAPPER_PATH="/usr/local/bin/mount-s3-wrapper.sh"
 SERVICE_PATH="/etc/systemd/system/mount-s3.service"
-LOG_DIR="/var/log/mountpoint"
 WATCHDOG_INTERVAL=10    # systemd WatchdogSec 秒
 
 # --- 2. mount-s3 本体のインストール ---
@@ -34,8 +33,8 @@ fi
 grep -q "^user_allow_other" /etc/fuse.conf || \
   echo "user_allow_other" | sudo tee -a /etc/fuse.conf
 
-mkdir -p "${TARGET_DIRECTORY}" /scratch "${LOG_DIR}"
-chmod 777 "${TARGET_DIRECTORY}" /scratch "${LOG_DIR}"
+mkdir -p "${TARGET_DIRECTORY}" /scratch
+chmod 777 "${TARGET_DIRECTORY}" /scratch
 
 # --- 4. wrapper スクリプト生成 ---
 cat << 'EOF' > "${WRAPPER_PATH}"

--- a/mount-s3/mount.sh
+++ b/mount-s3/mount.sh
@@ -22,7 +22,7 @@ WATCHDOG_INTERVAL=10    # systemd WatchdogSec 秒
 # --- 2. mount-s3 本体のインストール ---
 if ! command -v mount-s3 &>/dev/null; then
   apt-get -o DPkg::Lock::Timeout=300 update -y
-  apt-get -o DPkg::Lock::Timeout=300 install -y libfuse2
+  apt-get -o DPkg::Lock::Timeout=300 install -y libfuse2 dos2unix
   wget -O /tmp/mount-s3.deb \
     https://s3.amazonaws.com/mountpoint-s3-release/latest/x86_64/mount-s3.deb
   apt-get -o DPkg::Lock::Timeout=300 install -y /tmp/mount-s3.deb
@@ -42,43 +42,30 @@ cat << 'EOF' > "${WRAPPER_PATH}"
 #!/bin/bash
 set -eu
 
-BUCKET="$1"
-TARGET="$2"
+BUCKET_NAME="$1"
+TARGET_DIRECTORY="$2"
 shift 2
 OPTIONS=("$@")
 
-# 停止フラグ
-stop_requested=0
-trap 'stop_requested=1; kill "$child" 2>/dev/null' TERM INT
+# (1) mount-s3 をフォアグラウンド実行
+exec /usr/bin/mount-s3 "${BUCKET_NAME}" "${TARGET_DIRECTORY}" "${OPTIONS[@]}" --foreground &
+CHILD=$!
 
-# systemd-notify 用
+# (2) systemd に ready 通知
 export NOTIFY_SOCKET
+systemd-notify --ready --status="mount-s3 started (PID $CHILD)"
 
-# supervisor ループ
-while [ $stop_requested -eq 0 ]; do
-  # (1) mount-s3 起動
-  /usr/bin/mount-s3 "$BUCKET" "$TARGET" "${OPTIONS[@]}" --foreground &
-  child=$!
+# (3) systemd からのシグナルを子プロセスに転送
+trap 'kill -TERM $CHILD 2>/dev/null' TERM INT
 
-  # (2) 最初の ready 通知（一度だけ）
-  systemd-notify --ready --status="mount-s3 started (PID $child)"
-
-  # (3) child が死ぬまで待機 or stop 要求
-  while kill -0 "$child" 2>/dev/null; do
-    sleep 1
-  done
-
-  # (4) child exit
-  wait "$child" || true
-
-  # (5) stop 要求ならループ抜け
-  [ $stop_requested -eq 1 ] && break
-
-  # (6) まだサービス継続：ログだけ残して即再起動
-  echo "[$(date -Iseconds)] mount-s3 (PID $child) exited; restarting…" | systemd-cat -t mount-s3-supervisor
+# (4) 定期的に watchdog 通知
+while kill -0 "$CHILD" 2>/dev/null; do
+  systemd-notify WATCHDOG=1 --status="alive: ${CHILD}"
+  sleep 5
 done
 
-exit 0
+wait "$CHILD"
+exit $?
 EOF
 
 chmod +x "${WRAPPER_PATH}"
@@ -92,32 +79,24 @@ done
 
 cat << EOF > "${SERVICE_PATH}"
 [Unit]
-Description=Mount S3 Bucket via mount-s3 (supervised)
+Description=Mount S3 Bucket via mount-s3 (with watchdog)
 After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=notify
 NotifyAccess=main
+ExecStart=${WRAPPER_PATH} ${BUCKET_NAME} ${TARGET_DIRECTORY}${OPTS_JOINED}
 
-# supervisor をフォアグラウンド実行
-ExecStart=${WRAPPER_PATH} ${BUCKET_NAME} ${TARGET_DIRECTORY} ${OPTS_JOINED}
-
-# systemctl stop で wrapper に SIGTERM
-KillMode=control-group
-
-# 再起動させない（wrapper 内で再起動を制御）
-Restart=no
-
-# 必要なら Stop 時にアンマウント
-ExecStop=/usr/bin/fusermount -uz /s3/dataset
-TimeoutStopSec=20
-
+WatchdogSec=${WATCHDOG_INTERVAL}s
+Restart=always
+StartLimitBurst=5
+ExecStop=/bin/true
+RestartSec=2s
 LimitNOFILE=65536
 
 [Install]
 WantedBy=multi-user.target
-
 EOF
 
 # --- 6. systemd 再読み込み＆起動 ---

--- a/mount-s3/mount.sh
+++ b/mount-s3/mount.sh
@@ -55,11 +55,11 @@ systemd-notify --ready --status="mount-s3 started (PID $CHILD)"
 trap 'kill -TERM $CHILD 2>/dev/null' TERM INT
 
 # health-check loop
-while kill -0 $child 2>/dev/null; do
+while kill -0 $CHILD 2>/dev/null; do
   # 2) hungテスト
-  if ! timeout 5s ls "$TARGET" >/dev/null; then
+  if ! timeout 5s ls "${TARGET_DIRECTORY}" >/dev/null; then
     echo "[$(date)] I/O hang detected, killing child" | systemd-cat -t mount-s3
-    kill $child
+    kill $CHILD
     break
   fi
 

--- a/mount-s3/mount.sh
+++ b/mount-s3/mount.sh
@@ -29,4 +29,23 @@ chmod 777 /scratch
 mkdir -p ${TARGET_DIRECTORY}
 chmod 777 ${TARGET_DIRECTORY}
 
-mount-s3 ${BUCKET_NAME} ${TARGET_DIRECTORY} ${OPTIONS}
+sudo tee /etc/systemd/system/mount-s3.service << EOF
+[Unit]
+Description=Mount S3 Bucket via mount-s3
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=forking
+ExecStart=/usr/bin/mount-s3 ${BUCKET_NAME} ${TARGET_DIRECTORY} ${OPTIONS}
+Restart=on-failure
+RestartSec=5s
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable mount-s3.service
+sudo systemctl start mount-s3.service

--- a/mount-s3/mount.sh
+++ b/mount-s3/mount.sh
@@ -16,7 +16,6 @@ OPTIONS=("$@")
 # 固定パラメータ
 WRAPPER_PATH="/usr/local/bin/mount-s3-wrapper.sh"
 SERVICE_PATH="/etc/systemd/system/mount-s3.service"
-WATCHDOG_INTERVAL=10    # systemd WatchdogSec 秒
 
 # --- 2. mount-s3 本体のインストール ---
 if ! command -v mount-s3 &>/dev/null; then
@@ -46,10 +45,11 @@ TARGET_DIRECTORY="$2"
 shift 2
 OPTIONS=("$@")
 
-exec /usr/bin/mount-s3 "${BUCKET_NAME}" "${TARGET_DIRECTORY}" "${OPTIONS[@]}" --foreground &
+/usr/bin/mount-s3 "${BUCKET_NAME}" "${TARGET_DIRECTORY}" "${OPTIONS[@]}" --foreground &
 CHILD=$!
 
 export NOTIFY_SOCKET
+
 systemd-notify --ready --status="mount-s3 started (PID $CHILD)"
 
 trap 'kill -TERM $CHILD 2>/dev/null' TERM INT
@@ -63,7 +63,6 @@ while kill -0 $CHILD 2>/dev/null; do
     break
   fi
 
-  systemd-notify WATCHDOG=1
   sleep 5
 done
 
@@ -82,7 +81,7 @@ done
 
 cat << EOF > "${SERVICE_PATH}"
 [Unit]
-Description=Mount S3 Bucket via mount-s3 (with watchdog)
+Description=Mount S3 Bucket via mount-s3-wrapper
 After=network-online.target
 Wants=network-online.target
 
@@ -91,10 +90,7 @@ Type=notify
 NotifyAccess=main
 ExecStart=${WRAPPER_PATH} ${BUCKET_NAME} ${TARGET_DIRECTORY}${OPTS_JOINED}
 
-WatchdogSec=${WATCHDOG_INTERVAL}s
 Restart=always
-StartLimitBurst=5
-ExecStop=/bin/true
 RestartSec=2s
 LimitNOFILE=65536
 

--- a/mount-s3/mount.sh
+++ b/mount-s3/mount.sh
@@ -61,10 +61,11 @@ while kill -0 $CHILD 2>/dev/null; do
   if ! timeout 5s ls "${TARGET_DIRECTORY}" >/dev/null; then
     echo "[$(date)] I/O hang detected, killing child" | systemd-cat -t mount-s3
     kill $CHILD
-    break
+    exit 1
   fi
 
   sleep 5
+  systemd-notify WATCHDOG=1 --status="alive: ${CHILD}"
 done
 
 wait "$CHILD"
@@ -83,20 +84,24 @@ done
 cat << EOF > "${SERVICE_PATH}"
 [Unit]
 Description=Mount S3 Bucket via mount-s3-wrapper
-After=network-online.target
-Wants=network-online.target
+Wants=network.target
+AssertPathIsDirectory=${TARGET_DIRECTORY}
 
 [Service]
 Type=notify
 NotifyAccess=main
-ExecStart=${WRAPPER_PATH} ${BUCKET_NAME} ${TARGET_DIRECTORY}${OPTS_JOINED}
+User=ubuntu
+Group=ubuntu
+ExecStart=${WRAPPER_PATH} ${BUCKET_NAME} ${TARGET_DIRECTORY} ${OPTS_JOINED}
+ExecStop=/usr/bin/fusermount -u ${TARGET_DIRECTORY}
 
-Restart=always
+Restart=on-failure
+WatchdogSec=10s
 RestartSec=2s
 LimitNOFILE=65536
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=remote-fs.target
 EOF
 
 # --- 6. systemd 再読み込み＆起動 ---

--- a/mount-s3/mount.sh
+++ b/mount-s3/mount.sh
@@ -52,11 +52,12 @@ export NOTIFY_SOCKET
 
 systemd-notify --ready --status="mount-s3 started (PID $CHILD)"
 
+# systemctl stopコマンドを伝播する
 trap 'kill -TERM $CHILD 2>/dev/null' TERM INT
 
 # health-check loop
 while kill -0 $CHILD 2>/dev/null; do
-  # 2) hungテスト
+  # ls して5秒間 返答がなければプロセス停止する
   if ! timeout 5s ls "${TARGET_DIRECTORY}" >/dev/null; then
     echo "[$(date)] I/O hang detected, killing child" | systemd-cat -t mount-s3
     kill $CHILD

--- a/mount-s3/mount.sh
+++ b/mount-s3/mount.sh
@@ -89,7 +89,7 @@ AssertPathIsDirectory=${TARGET_DIRECTORY}
 
 [Service]
 Type=notify
-NotifyAccess=main
+NotifyAccess=all
 User=ubuntu
 Group=ubuntu
 ExecStart=${WRAPPER_PATH} ${BUCKET_NAME} ${TARGET_DIRECTORY} ${OPTS_JOINED}

--- a/mount-s3/mount.sh
+++ b/mount-s3/mount.sh
@@ -95,7 +95,7 @@ Group=ubuntu
 ExecStart=${WRAPPER_PATH} ${BUCKET_NAME} ${TARGET_DIRECTORY} ${OPTS_JOINED}
 ExecStop=/usr/bin/fusermount -u ${TARGET_DIRECTORY}
 
-Restart=on-failure
+Restart=on-failure,on-watchdog
 WatchdogSec=10s
 RestartSec=2s
 LimitNOFILE=65536

--- a/mount-s3/mount.sh
+++ b/mount-s3/mount.sh
@@ -22,7 +22,7 @@ WATCHDOG_INTERVAL=10    # systemd WatchdogSec 秒
 # --- 2. mount-s3 本体のインストール ---
 if ! command -v mount-s3 &>/dev/null; then
   apt-get -o DPkg::Lock::Timeout=300 update -y
-  apt-get -o DPkg::Lock::Timeout=300 install -y libfuse2 dos2unix
+  apt-get -o DPkg::Lock::Timeout=300 install -y libfuse2
   wget -O /tmp/mount-s3.deb \
     https://s3.amazonaws.com/mountpoint-s3-release/latest/x86_64/mount-s3.deb
   apt-get -o DPkg::Lock::Timeout=300 install -y /tmp/mount-s3.deb
@@ -42,30 +42,43 @@ cat << 'EOF' > "${WRAPPER_PATH}"
 #!/bin/bash
 set -eu
 
-BUCKET_NAME="$1"
-TARGET_DIRECTORY="$2"
+BUCKET="$1"
+TARGET="$2"
 shift 2
 OPTIONS=("$@")
 
-# (1) mount-s3 をフォアグラウンド実行
-exec /usr/bin/mount-s3 "${BUCKET_NAME}" "${TARGET_DIRECTORY}" "${OPTIONS[@]}" --foreground &
-CHILD=$!
+# 停止フラグ
+stop_requested=0
+trap 'stop_requested=1; kill "$child" 2>/dev/null' TERM INT
 
-# (2) systemd に ready 通知
+# systemd-notify 用
 export NOTIFY_SOCKET
-systemd-notify --ready --status="mount-s3 started (PID $CHILD)"
 
-# (3) systemd からのシグナルを子プロセスに転送
-trap 'kill -TERM $CHILD 2>/dev/null' TERM INT
+# supervisor ループ
+while [ $stop_requested -eq 0 ]; do
+  # (1) mount-s3 起動
+  /usr/bin/mount-s3 "$BUCKET" "$TARGET" "${OPTIONS[@]}" --foreground &
+  child=$!
 
-# (4) 定期的に watchdog 通知
-while kill -0 "$CHILD" 2>/dev/null; do
-  systemd-notify WATCHDOG=1 --status="alive: ${CHILD}"
-  sleep 5
+  # (2) 最初の ready 通知（一度だけ）
+  systemd-notify --ready --status="mount-s3 started (PID $child)"
+
+  # (3) child が死ぬまで待機 or stop 要求
+  while kill -0 "$child" 2>/dev/null; do
+    sleep 1
+  done
+
+  # (4) child exit
+  wait "$child" || true
+
+  # (5) stop 要求ならループ抜け
+  [ $stop_requested -eq 1 ] && break
+
+  # (6) まだサービス継続：ログだけ残して即再起動
+  echo "[$(date -Iseconds)] mount-s3 (PID $child) exited; restarting…" | systemd-cat -t mount-s3-supervisor
 done
 
-wait "$CHILD"
-exit $?
+exit 0
 EOF
 
 chmod +x "${WRAPPER_PATH}"
@@ -79,24 +92,32 @@ done
 
 cat << EOF > "${SERVICE_PATH}"
 [Unit]
-Description=Mount S3 Bucket via mount-s3 (with watchdog)
+Description=Mount S3 Bucket via mount-s3 (supervised)
 After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=notify
 NotifyAccess=main
-ExecStart=${WRAPPER_PATH} ${BUCKET_NAME} ${TARGET_DIRECTORY}${OPTS_JOINED}
 
-WatchdogSec=${WATCHDOG_INTERVAL}s
-Restart=always
-StartLimitBurst=5
-ExecStop=/bin/true
-RestartSec=2s
+# supervisor をフォアグラウンド実行
+ExecStart=${WRAPPER_PATH} ${BUCKET_NAME} ${TARGET_DIRECTORY} ${OPTS_JOINED}
+
+# systemctl stop で wrapper に SIGTERM
+KillMode=control-group
+
+# 再起動させない（wrapper 内で再起動を制御）
+Restart=no
+
+# 必要なら Stop 時にアンマウント
+ExecStop=/usr/bin/fusermount -uz /s3/dataset
+TimeoutStopSec=20
+
 LimitNOFILE=65536
 
 [Install]
 WantedBy=multi-user.target
+
 EOF
 
 # --- 6. systemd 再読み込み＆起動 ---

--- a/mount-s3/mount.sh
+++ b/mount-s3/mount.sh
@@ -1,51 +1,108 @@
 #!/bin/bash
+set -euxo pipefail
 
-BUCKET_NAME=$1
-TARGET_DIRECTORY=$2
-OPTIONS="${@:3}"
+# 引数チェック
+if [ "$#" -lt 2 ]; then
+  echo "Usage: $0 <BUCKET_NAME> <TARGET_DIRECTORY> [OPTIONS...]"
+  exit 1
+fi
 
-# Install mount-s3 command for Ubuntu 22.04
-if ! command -v mount-s3 &> /dev/null
-then
+# --- 1. パラメータ分解 ---
+BUCKET_NAME="$1"
+TARGET_DIRECTORY="$2"
+shift 2
+OPTIONS=("$@")
+
+# 固定パラメータ
+WRAPPER_PATH="/usr/local/bin/mount-s3-wrapper.sh"
+SERVICE_PATH="/etc/systemd/system/mount-s3.service"
+LOG_DIR="/var/log/mountpoint"
+WATCHDOG_INTERVAL=10    # systemd WatchdogSec 秒
+
+# --- 2. mount-s3 本体のインストール ---
+if ! command -v mount-s3 &>/dev/null; then
   apt-get -o DPkg::Lock::Timeout=300 update -y
-  apt-get -o DPkg::Lock::Timeout=300 install -y libfuse2
-  wget -O /tmp/mount-s3.deb https://s3.amazonaws.com/mountpoint-s3-release/latest/x86_64/mount-s3.deb
+  apt-get -o DPkg::Lock::Timeout=300 install -y libfuse2 dos2unix
+  wget -O /tmp/mount-s3.deb \
+    https://s3.amazonaws.com/mountpoint-s3-release/latest/x86_64/mount-s3.deb
   apt-get -o DPkg::Lock::Timeout=300 install -y /tmp/mount-s3.deb
 else
   echo "mount-s3 is already installed."
 fi
 
-# Needed if --allow-root or --allow-other option is set
-if ! grep -q "^user_allow_other" /etc/fuse.conf
-then
-    echo "user_allow_other" | sudo tee -a /etc/fuse.conf
-fi
+# --- 3. FUSE 設定とディレクトリ準備 ---
+grep -q "^user_allow_other" /etc/fuse.conf || \
+  echo "user_allow_other" | sudo tee -a /etc/fuse.conf
 
-# Create cache directory
-mkdir -p /scratch
-chmod 777 /scratch
+mkdir -p "${TARGET_DIRECTORY}" /scratch "${LOG_DIR}"
+chmod 777 "${TARGET_DIRECTORY}" /scratch "${LOG_DIR}"
 
-# Create mount target directory
-mkdir -p ${TARGET_DIRECTORY}
-chmod 777 ${TARGET_DIRECTORY}
+# --- 4. wrapper スクリプト生成 ---
+cat << 'EOF' > "${WRAPPER_PATH}"
+#!/bin/bash
+set -eu
 
-sudo tee /etc/systemd/system/mount-s3.service << EOF
+BUCKET_NAME="$1"
+TARGET_DIRECTORY="$2"
+shift 2
+OPTIONS=("$@")
+
+# (1) mount-s3 をフォアグラウンド実行
+exec /usr/bin/mount-s3 "${BUCKET_NAME}" "${TARGET_DIRECTORY}" "${OPTIONS[@]}" --foreground &
+CHILD=$!
+
+# (2) systemd に ready 通知
+export NOTIFY_SOCKET
+systemd-notify --ready --status="mount-s3 started (PID $CHILD)"
+
+# (3) systemd からのシグナルを子プロセスに転送
+trap 'kill -TERM $CHILD 2>/dev/null' TERM INT
+
+# (4) 定期的に watchdog 通知
+while kill -0 "$CHILD" 2>/dev/null; do
+  systemd-notify WATCHDOG=1 --status="alive: ${CHILD}"
+  sleep 5
+done
+
+wait "$CHILD"
+exit $?
+EOF
+
+chmod +x "${WRAPPER_PATH}"
+
+# --- 5. systemd ユニット生成 ---
+# OPTIONS をそのまま ExecStart に渡すために join
+OPTS_JOINED=""
+for o in "${OPTIONS[@]}"; do
+  OPTS_JOINED+=" ${o}"
+done
+
+cat << EOF > "${SERVICE_PATH}"
 [Unit]
-Description=Mount S3 Bucket via mount-s3
+Description=Mount S3 Bucket via mount-s3 (with watchdog)
 After=network-online.target
 Wants=network-online.target
 
 [Service]
-Type=forking
-ExecStart=/usr/bin/mount-s3 ${BUCKET_NAME} ${TARGET_DIRECTORY} ${OPTIONS}
-Restart=on-failure
-RestartSec=5s
+Type=notify
+NotifyAccess=main
+ExecStart=${WRAPPER_PATH} ${BUCKET_NAME} ${TARGET_DIRECTORY}${OPTS_JOINED}
+
+WatchdogSec=${WATCHDOG_INTERVAL}s
+Restart=always
+StartLimitBurst=5
+ExecStop=/bin/true
+RestartSec=2s
 LimitNOFILE=65536
 
 [Install]
 WantedBy=multi-user.target
 EOF
 
-sudo systemctl daemon-reload
-sudo systemctl enable mount-s3.service
-sudo systemctl start mount-s3.service
+# --- 6. systemd 再読み込み＆起動 ---
+systemctl daemon-reload
+systemctl enable mount-s3.service
+systemctl restart mount-s3.service
+
+echo "mount-s3.service installed and started."
+

--- a/mount-s3/mount.sh
+++ b/mount-s3/mount.sh
@@ -46,20 +46,24 @@ TARGET_DIRECTORY="$2"
 shift 2
 OPTIONS=("$@")
 
-# (1) mount-s3 をフォアグラウンド実行
 exec /usr/bin/mount-s3 "${BUCKET_NAME}" "${TARGET_DIRECTORY}" "${OPTIONS[@]}" --foreground &
 CHILD=$!
 
-# (2) systemd に ready 通知
 export NOTIFY_SOCKET
 systemd-notify --ready --status="mount-s3 started (PID $CHILD)"
 
-# (3) systemd からのシグナルを子プロセスに転送
 trap 'kill -TERM $CHILD 2>/dev/null' TERM INT
 
-# (4) 定期的に watchdog 通知
-while kill -0 "$CHILD" 2>/dev/null; do
-  systemd-notify WATCHDOG=1 --status="alive: ${CHILD}"
+# health-check loop
+while kill -0 $child 2>/dev/null; do
+  # 2) hungテスト
+  if ! timeout 5s ls "$TARGET" >/dev/null; then
+    echo "[$(date)] I/O hang detected, killing child" | systemd-cat -t mount-s3
+    kill $child
+    break
+  fi
+
+  systemd-notify WATCHDOG=1
   sleep 5
 done
 


### PR DESCRIPTION
JIRA: https://turing-motors.atlassian.net/browse/MLOP-448
mount-s3がhungする問題の対応として、systemdで起動し、自動再起動するようにします。


概要説明
- mount-s3のラッパースクリプトを作成し、systemdから起動させる
- マウントするディレクトリを定期的にls し、timeoutしたらプロセスをkillする