### PR TITLE
metadata-ttlをスクリプト側で定義

### DIFF
--- a/mount-s3/mount.sh
+++ b/mount-s3/mount.sh
@@ -29,4 +29,5 @@ chmod 777 /scratch
 mkdir -p ${TARGET_DIRECTORY}
 chmod 777 ${TARGET_DIRECTORY}
 
+ulimit -S -n 65536
 mount-s3 ${BUCKET_NAME} ${TARGET_DIRECTORY} ${OPTIONS} --metadata-ttl indefinite

--- a/mount-s3/mount.sh
+++ b/mount-s3/mount.sh
@@ -29,5 +29,4 @@ chmod 777 /scratch
 mkdir -p ${TARGET_DIRECTORY}
 chmod 777 ${TARGET_DIRECTORY}
 
-ulimit -S -n 65536
-mount-s3 ${BUCKET_NAME} ${TARGET_DIRECTORY} ${OPTIONS} --metadata-ttl indefinite
+mount-s3 ${BUCKET_NAME} ${TARGET_DIRECTORY} ${OPTIONS} --metadata-ttl indefinite --negative-metadata-ttl minimal

--- a/mount-s3/mount.sh
+++ b/mount-s3/mount.sh
@@ -29,4 +29,4 @@ chmod 777 /scratch
 mkdir -p ${TARGET_DIRECTORY}
 chmod 777 ${TARGET_DIRECTORY}
 
-mount-s3 ${BUCKET_NAME} ${TARGET_DIRECTORY} ${OPTIONS}
+mount-s3 ${BUCKET_NAME} ${TARGET_DIRECTORY} ${OPTIONS} --metadata-ttl indefinite


### PR DESCRIPTION
JIRA: https://turing-motors.atlassian.net/browse/MLOP-432

parallel clusterのterraformコードに実装していたため、クラスタが再作成されない限り設定反映されない状態になっていた。
ノード起動時に反映させるため、マウントスクリプトに設定を書くようにする